### PR TITLE
Update Lorenz example: fix #11

### DIFF
--- a/content/notebooks/Lorenz.ipynb
+++ b/content/notebooks/Lorenz.ipynb
@@ -53,7 +53,7 @@
         "    max_time = 4.0\n",
         "    N = 30\n",
         "\n",
-        "    fig = plt.figure()\n",
+        "    fig = plt.figure(1)\n",
         "    ax = fig.add_axes([0, 0, 1, 1], projection='3d')\n",
         "    ax.axis('off')\n",
         "\n",


### PR DESCRIPTION
Should fix the Matplotlib RuntimeWarning about many opened Figures (Issue #11 )