### PR TITLE
Update to `jupyterlite==0.1.0b9`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,13 +3,13 @@ ipycanvas>=0.9.1
 ipyleaflet
 ipympl>=0.8.2
 ipywidgets>=7.7,<8
-jupyterlab~=3.3.0
+jupyterlab~=3.4.3
 jupyterlab-language-pack-fr-FR
 jupyterlab-language-pack-zh-CN
 jupyterlab-fasta>=3,<4
 jupyterlab-geojson>=3,<4
 jupyterlab-tour
-jupyterlite==0.1.0b8
+jupyterlite==0.1.0b9
 jupyterlite-xeus-sqlite==0.1.2
 plotly>=5,<6
 theme-darcula


### PR DESCRIPTION
Update to the latest release: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b9

cc @choldgraf this release adds support for accessing files from the Python kernel, which reduces the gap between "normal Jupyter" and JupyterLite:

- https://github.com/jupyterlite/jupyterlite/pull/655
- https://jupyterlite.readthedocs.io/en/latest/howto/content/python.html

Which means we could also update the content, for example to show how to read a csv file with pandas:

```py
import pandas as pd
df = pd.read_csv('iris.csv')
df
```