### PR TITLE
Update to `jupyterlite==0.1.0b14`

### DIFF
--- a/content/notebooks/Lorenz.ipynb
+++ b/content/notebooks/Lorenz.ipynb
@@ -17,6 +17,15 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install -q ipywidgets"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "trusted": true
       },
@@ -25,9 +34,6 @@
         "import numpy as np\n",
         "from matplotlib import pyplot as plt\n",
         "from scipy import integrate\n",
-        "\n",
-        "import piplite\n",
-        "await piplite.install('ipywidgets')\n",
         "\n",
         "from ipywidgets import interactive, fixed"
       ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ jupyterlab-language-pack-zh-CN
 jupyterlab-fasta>=3,<4
 jupyterlab-geojson>=3,<4
 jupyterlab-tour
-jupyterlite==0.1.0b13
+jupyterlite==0.1.0b14
 jupyterlite-xeus-sqlite==0.1.2
 plotly>=5,<6
 theme-darcula


### PR DESCRIPTION
update to the latest release: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b14

This allows using the `%pip` magic to install `ipywidgets` instead of `piplite`, which might look more familiar to notebook users.