### PR TITLE
Update to `jupyterlite-core==0.1.0b20`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
 - jupyterlab-night
 - plotly>=5,<6
 - pip:
-  - jupyterlite-sphinx
-  - jupyterlite==0.1.0b19
+  - jupyterlite-sphinx>=0.8.0,<0.9
+  - jupyterlite-core==0.1.0b20
+  - jupyterlite-pyodide-kernel==0.0.5
   - jupyterlite-xeus-sqlite==0.2.1

--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -4,7 +4,6 @@
     "appName": "Try Jupyter!",
     "disabledExtensions": [
       "@jupyterlab/server-proxy",
-      "@jupyterlite/javascript-kernel-extension",
       "jupyterlab-server-proxy",
       "nbdime-jupyterlab"
     ]


### PR DESCRIPTION
Update to the latest release: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b20

The JavaScript kernel is not part of the main bundle, clean up `jupyter-lite.json`.