### PR TITLE
Add `jupyterlab-open-url-parameter`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,3 +24,4 @@ dependencies:
   - jupyterlite-core==0.1.0
   - jupyterlite-pyodide-kernel==0.0.6
   - jupyterlite-xeus-sqlite==0.2.1
+  - jupyterlab-open-url-parameter


### PR DESCRIPTION
Add the `jupyterlab-open-url-parameter` extension so end users could potentially use this JupyterLite deployment but load notebooks from a different location.

For reference this is documented in: https://jupyterlite.readthedocs.io/en/latest/howto/content/open-url-parameter.html