### PR TITLE
Update to `jupyterlite-pyodide-kernel==0.0.10`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
 - plotly>=5,<6
 - pip:
   - jupyterlite-sphinx>=0.8.0,<0.9
-  - jupyterlite-core==0.1.0
-  - jupyterlite-pyodide-kernel==0.0.6
+  - jupyterlite-core==0.1.1
+  - jupyterlite-pyodide-kernel==0.0.10
   - jupyterlite-xeus-sqlite==0.2.1
   - jupyterlab-open-url-parameter


### PR DESCRIPTION
To fix compatibility with ipywidgets 8.1.0.