### PR TITLE
Update to `jupyterlite-pyodide-kernel=0.1.1`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
 - jupyterlab-tour
 - jupyterlab-night
 - jupyterlite-core=0.1.2
-- jupyterlite-pyodide-kernel=0.1.0
+- jupyterlite-pyodide-kernel=0.1.1
 - jupyterlite-sphinx>=0.9.1,<0.10
 - plotly>=5,<6
 - pip:


### PR DESCRIPTION
Which should bring a fix to the use of the service worker: https://github.com/jupyterlite/pyodide-kernel/releases/tag/v0.1.1