### PR TITLE
Update to JupyterLite 0.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,16 +11,18 @@ dependencies:
 - ipyleaflet
 - ipympl >=0.8.2
 - ipywidgets >=8.1.1,<9
-- jupyterlab >=3.5.2,<4
+- jupyterlab >=4.0.9,<5
 - jupyterlab-language-pack-fr-FR
 - jupyterlab-language-pack-zh-CN
-- jupyterlab-fasta >=3,<4
-- jupyterlab-geojson >=3,<4
-- jupyterlab-tour
+- jupyterlab-fasta >=3.3.0,<4
+- jupyterlab-geojson >=3.4.0,<4
+# currently broken: https://github.com/jupyterlab-contrib/jupyterlab-tour/issues/82
+# - jupyterlab-tour
 - jupyterlab-night
-- jupyterlite-core =0.1.3
-- jupyterlite-pyodide-kernel =0.1.3
-- jupyterlite-sphinx >=0.9.1,<0.10
+- jupyterlite-core =0.2.1
+- jupyterlite-pyodide-kernel =0.2.0
+- jupyterlite-sphinx >=0.10.0,<0.11
+- notebook >=7.0.6
 - pip
 - plotly >=5,<6
 - pip:


### PR DESCRIPTION
Update to JupyterLite 0.2 which is now based on JupyterLab 4 and Notebook 7: https://jupyterlite.readthedocs.io/en/stable/migration.html#to-0-2-0