### PR TITLE
Update JupyterLite dependencies to the latest `0.5.x` versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,8 +18,8 @@ dependencies:
 - jupyterlab-geojson >=3.4.0,<4
 - jupyterlab-tour
 - jupyterlab-night
-- jupyterlite-core =0.5.0
-- jupyterlite-pyodide-kernel =0.5.0
+- jupyterlite-core =0.5.1
+- jupyterlite-pyodide-kernel =0.5.2
 - jupyterlite-sphinx >=0.18.0,<0.19
 - notebook >=7.3.2,<7.4
 - pip


### PR DESCRIPTION
Mechanical bump to grab some updates and fixes.